### PR TITLE
Added warning about incompatibility with other programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 This is the PalWorld network cracking framework
 modifying player data in the Player tab
 Network cracking in the Exploit tab
-# Note: The master branch does not include visual
 
 >[!Warning]
 >Incompatible with other programs and overlays which also access the game. 
 >For example:
 >- blitz.gg
+
+# Note: The master branch does not include visual
 
 # Player Features
 - Modify Player Speed (Player not world)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ modifying player data in the Player tab
 Network cracking in the Exploit tab
 # Note: The master branch does not include visual
 
+>[!Warning]
+>Incompatible with other programs and overlays which also access the game. 
+>For example:
+>- blitz.gg
+
 # Player Features
 - Modify Player Speed (Player not world)
 - Modify Player Attack Power


### PR DESCRIPTION
As I just found out after half an hour of debugging, blitz.gg also hooks into Palworld for its integration. 
`'Palworld-Win64-Shipping.exe' (Win32): Loaded 'C:\Users\xyz\AppData\Roaming\Blitz\blitz-deps\2.1.124\blitz_palworld.dll'. `

This causes an immediate crash to desktop if you try to inject the NetCrack.dll

